### PR TITLE
Feature: Support Injecting Textures into Objects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "exoquant"]
+	path = exoquant
+	url = https://github.com/exoticorn/exoquant

--- a/build-debug.sh
+++ b/build-debug.sh
@@ -1,3 +1,3 @@
 mkdir -p bin/
-gcc -o bin/z64yartool -Og -g -Wall -Wextra -Wno-unused-function -lm -std=c99 -pedantic -Iinclude src/*.c
+gcc -o bin/z64yartool -Og -g -Wall -Wextra -Wno-unused-function -std=c99 -pedantic -Iinclude src/*.c -lm
 

--- a/build-debug.sh
+++ b/build-debug.sh
@@ -1,3 +1,3 @@
 mkdir -p bin/
-gcc -o bin/z64yartool -Og -g -Wall -Wextra -Wno-unused-function -std=c99 -pedantic -Iinclude src/*.c -lm
+gcc -o bin/z64yartool -Og -g -Wall -Wextra -Wno-unused-function -std=c99 -pedantic -Iinclude -Iexoquant src/*.c exoquant/*.c -lm
 

--- a/include/n64texconv.h
+++ b/include/n64texconv.h
@@ -76,5 +76,17 @@ n64texconv_to_n64(
 	, unsigned int *sz
 );
 
+
+const char *
+n64texconv_to_n64_and_back(
+	unsigned char *pix
+	, unsigned char *pal
+	, int pal_colors
+	, enum n64texconv_fmt fmt
+	, enum n64texconv_bpp bpp
+	, int w
+	, int h
+);
+
 #endif /* N64TEXCONV_H_INCLUDED */
 

--- a/include/recipe.h
+++ b/include/recipe.h
@@ -8,6 +8,8 @@
 #ifndef RECIPE_H_INCLUDED
 #define RECIPE_H_INCLUDED
 
+#include <stdbool.h>
+
 #include "n64texconv.h" // for texture formats
 
 struct RecipeItem
@@ -16,13 +18,19 @@ struct RecipeItem
 	char *imageFilename;
 	int width;
 	int height;
+	int palId;
+	int palMaxColors;
 	enum n64texconv_fmt fmt;
 	enum n64texconv_bpp bpp;
+	unsigned int writeAt;
 	unsigned int endOffset;
+	void *data;
+	bool isAlreadyWritten;
 };
 
 struct Recipe
 {
+	char *behavior;
 	char *filename;
 	char *directory;
 	char *yarName;

--- a/include/recipe.h
+++ b/include/recipe.h
@@ -24,7 +24,7 @@ struct RecipeItem
 	enum n64texconv_bpp bpp;
 	unsigned int writeAt;
 	unsigned int endOffset;
-	void *data;
+	void *udata;
 	bool isAlreadyWritten;
 };
 

--- a/release-win32.sh
+++ b/release-win32.sh
@@ -1,3 +1,3 @@
 mkdir -p bin/
-i686-w64-mingw32.static-gcc -o bin/z64yartool.exe -Os -s -flto -DNDEBUG -Wall -Wextra -Wno-unused-function -std=c99 -pedantic -Iinclude src/*.c -lm
+i686-w64-mingw32.static-gcc -o bin/z64yartool.exe -Os -s -flto -DNDEBUG -Wall -Wextra -Wno-unused-function -std=c99 -pedantic -Iinclude -Iexoquant src/*.c  exoquant/*.c -lm
 

--- a/release-win32.sh
+++ b/release-win32.sh
@@ -1,3 +1,3 @@
 mkdir -p bin/
-i686-w64-mingw32.static-gcc -o bin/z64yartool.exe -Os -s -flto -DNDEBUG -Wall -Wextra -Wno-unused-function -lm -std=c99 -pedantic -Iinclude src/*.c
+i686-w64-mingw32.static-gcc -o bin/z64yartool.exe -Os -s -flto -DNDEBUG -Wall -Wextra -Wno-unused-function -std=c99 -pedantic -Iinclude src/*.c -lm
 

--- a/src/n64texconv.c
+++ b/src/n64texconv.c
@@ -785,3 +785,27 @@ n64texconv_to_n64(
 	return 0;
 }
 
+
+const char *
+n64texconv_to_n64_and_back(
+	unsigned char *pix
+	, unsigned char *pal
+	, int pal_colors
+	, enum n64texconv_fmt fmt
+	, enum n64texconv_bpp bpp
+	, int w
+	, int h
+)
+{
+	const char *err;
+	
+	err = n64texconv_to_n64(pix, pix, pal, pal_colors, fmt, bpp, w, h, 0);
+	if (err)
+		return err;
+	
+	err = n64texconv_to_rgba8888(pix, pix, pal, fmt, bpp, w, h);
+	if (err)
+		return err;
+	
+	return 0;
+}

--- a/src/recipe.c
+++ b/src/recipe.c
@@ -175,6 +175,7 @@ void RecipeFree(struct Recipe *recipe)
 	free(recipe->directory);
 	free(recipe->yarName);
 	free(recipe->imageDir);
+	free(recipe->behavior);
 	free(recipe);
 }
 

--- a/src/recipe.c
+++ b/src/recipe.c
@@ -21,7 +21,6 @@ struct Recipe *RecipeRead(const char *filename)
 	const char *step;
 	 // color-indexed formats are unsupported for now
 	const char *knownFmt = "rgba16, rgba32, ia4, ia8, ia16, i4, i8";
-	const char *behaviors = "z64retexture, etc";
 	
 	if (!data)
 	{
@@ -42,7 +41,7 @@ struct Recipe *RecipeRead(const char *filename)
 	assert(step);
 	
 	// not a behavior
-	if (!strstr(behaviors, recipe->behavior))
+	if (recipe->behavior[0] != '*')
 	{
 		recipe->yarName = Strdup(recipe->behavior);
 		strcpy(recipe->behavior, "");

--- a/src/recipe.c
+++ b/src/recipe.c
@@ -39,7 +39,6 @@ struct Recipe *RecipeRead(const char *filename)
 	recipe->directory = FileGetDirectory(filename);
 	recipe->behavior = StrdupContiguous(step);
 	
-	step = StringNextLine(step);
 	assert(step);
 	
 	// not a behavior
@@ -50,6 +49,7 @@ struct Recipe *RecipeRead(const char *filename)
 	}
 	else
 	{
+		step = StringNextLine(step);
 		recipe->yarName = StrdupContiguous(step);
 	}
 	

--- a/src/recipe.c
+++ b/src/recipe.c
@@ -21,6 +21,7 @@ struct Recipe *RecipeRead(const char *filename)
 	const char *step;
 	 // color-indexed formats are unsupported for now
 	const char *knownFmt = "rgba16, rgba32, ia4, ia8, ia16, i4, i8";
+	const char *behaviors = "z64retexture, etc";
 	
 	if (!data)
 	{
@@ -30,13 +31,29 @@ struct Recipe *RecipeRead(const char *filename)
 	
 	assert(recipe);
 	
+	step = data;
+	while (*step == '#')
+		step = StringNextLine(step);
+	
 	recipe->filename = Strdup(filename);
 	recipe->directory = FileGetDirectory(filename);
-	recipe->yarName = StrdupContiguous(data);
+	recipe->behavior = StrdupContiguous(step);
 	
-	step = data;
 	step = StringNextLine(step);
 	assert(step);
+	
+	// not a behavior
+	if (!strstr(behaviors, recipe->behavior))
+	{
+		recipe->yarName = Strdup(recipe->behavior);
+		strcpy(recipe->behavior, "");
+	}
+	else
+	{
+		recipe->yarName = StrdupContiguous(step);
+	}
+	
+	step = StringNextLine(step);
 	recipe->imageDir = StrdupContiguous(step);
 	
 	// ensure ends in a slash
@@ -55,14 +72,20 @@ struct Recipe *RecipeRead(const char *filename)
 		struct RecipeItem *this = calloc(1, sizeof(*this));
 		char *tmp = StrdupContiguous(step);
 		char fmt[32];
+		char filename[512];
+		int palId = -1;
+		int palMaxColors = 0;
 		int width;
 		int height;
+		unsigned int writeAt = -1;
 		
 		recipe->count += 1;
 		
 		assert(this);
 		
-		if (sscanf(tmp, "%dx%d,%[^,]", &width, &height, fmt) != 3)
+		if (sscanf(tmp, "%dx%d,%[^,],%[^, #\r\n],%x", &width, &height, fmt, filename, &writeAt) < 4
+			&& sscanf(tmp, "%d,pal-%d,%[^,],%[^, #\r\n],%x", &palMaxColors, &palId, fmt, filename, &writeAt) < 4
+		)
 		{
 			fprintf(stderr, "unexpectedly formatted line: '%s'\n", tmp);
 			exit(EXIT_FAILURE);
@@ -71,8 +94,8 @@ struct Recipe *RecipeRead(const char *filename)
 		// TODO check each combination individually since there are so few
 		if (strstr(fmt, "rgba"))
 			this->fmt = N64TEXCONV_RGBA;
-		//else if (strstr(fmt, "ci")) // color-indexed formats are unsupported for now
-		//	this->fmt = N64TEXCONV_CI;
+		else if (strstr(fmt, "ci")) // color-indexed formats are unsupported for now
+			this->fmt = N64TEXCONV_CI;
 		else if (strstr(fmt, "ia"))
 			this->fmt = N64TEXCONV_IA;
 		else if (strstr(fmt, "i"))
@@ -96,10 +119,33 @@ struct Recipe *RecipeRead(const char *filename)
 			exit(EXIT_FAILURE);
 		}
 		
+		// get palette id
+		if (this->fmt == N64TEXCONV_CI)
+		{
+			if (!strrchr(fmt, '-')
+				|| sscanf(strrchr(fmt, '-') + 1, "%d", &palId) != 1
+			)
+			{
+				fprintf(stderr, "provided ci format w/o specifying which palette: '%s'\n", fmt);
+				fprintf(stderr, "(ci4 and ci8 are expected to end in -n, where n = palette id)\n");
+				fprintf(stderr, "(for example: ci8-0 specifies ci8 format using palette 0)\n");
+				exit(EXIT_FAILURE);
+			}
+		}
+		
 		this->width = width;
 		this->height = height;
-		this->imageFilename = malloc(strlen(recipe->imageDir) + strlen(tmp) + 1);
-		sprintf(this->imageFilename, "%s%s", recipe->imageDir, strrchr(tmp, ',') + 1);
+		this->writeAt = writeAt;
+		this->palId = palId;
+		this->palMaxColors = palMaxColors;
+		
+		if (palMaxColors && !strcmp(filename, "auto"))
+			this->imageFilename = Strdup(filename);
+		else
+		{
+			this->imageFilename = malloc(strlen(recipe->imageDir) + strlen(filename) + 1);
+			sprintf(this->imageFilename, "%s%s", recipe->imageDir, filename);
+		}
 		
 		if (prev)
 			prev->next = this;
@@ -142,6 +188,11 @@ void RecipePrint(struct Recipe *recipe)
 	fprintf(stderr, " items:\n");
 	
 	for (struct RecipeItem *this = recipe->head; this; this = this->next)
-		fprintf(stderr, "  '%s', %dx%d\n", this->imageFilename, this->width, this->height);
+	{
+		fprintf(stderr, "  '%s', %dx%d", this->imageFilename, this->width, this->height);
+		if (this->writeAt != (unsigned int)-1) fprintf(stderr, ", .writeAt = 0x%x", this->writeAt);
+		if (this->palId >= 0) fprintf(stderr, ", .palId = %d", this->palId);
+		fprintf(stderr, "\n");
+	}
 }
 

--- a/src/z64yartool.c
+++ b/src/z64yartool.c
@@ -449,6 +449,7 @@ static int RetextureBuild(struct Recipe *recipe)
 		// if palette name != auto, load it from image file
 		if (strcmp(pal->imageFilename, "auto"))
 		{
+			// TODO still need to handle mapping textures to the palette if this scenario
 			RetextureBuildInject(pal, &data, &dataSz);
 			continue;
 		}
@@ -526,9 +527,10 @@ static int RetextureBuild(struct Recipe *recipe)
 			// 4-bit
 			if (this->bpp == N64TEXCONV_4)
 			{
-				fprintf(stderr, "warning: z64yartool needs ci4 conversion\n");
-				// TODO format conversion
+				// squash 8-bit bytes '01 02 03 04' into 4-bit '12 34'
 				bytes /= 2;
+				for (int i = 0; i < bytes; ++i)
+					buffer2[i] = (buffer2[i * 2] << 4) | (buffer2[i * 2 + 1] & 0xf);
 			}
 			
 			// write the texture

--- a/src/z64yartool.c
+++ b/src/z64yartool.c
@@ -367,9 +367,11 @@ static int RetextureBuildInject(struct RecipeItem *this, uint8_t **data, size_t 
 	
 	this->isAlreadyWritten = true;
 	
-	// TODO support this format
+	// color-indexed textures are handled in a previous step
 	if (this->fmt == N64TEXCONV_CI)
 	{
+		// so this should never be printed; if this texture was
+		// handled in a previous step, isAlreadyWritten == true
 		fprintf(stderr, "skipping '%s'\n", imgFn);
 		return EXIT_SUCCESS;
 	}
@@ -549,7 +551,9 @@ static int RetextureBuild(struct Recipe *recipe)
 			if (!udata)
 				continue;
 			
-			if (true) // dithering
+			if (strstr(recipe->behavior, "random-dither"))
+				exq_map_image_dither(quant, w, h, this->udata, buffer2, 0);
+			else if (strstr(recipe->behavior, "dither"))
 				exq_map_image_ordered(quant, w, h, this->udata, buffer2);
 			else
 				exq_map_image(quant, w * h, this->udata, buffer2);
@@ -640,7 +644,7 @@ int main(int argc, const char *argv[])
 		{
 			RecipePrint(recipe);
 		}
-		else if (!strcmp(recipe->behavior, "z64retexture"))
+		else if (recipe->behavior[0] == '*')
 		{
 			if (isDump)
 				rval = RetextureDump(recipe);

--- a/src/z64yartool.c
+++ b/src/z64yartool.c
@@ -554,6 +554,7 @@ static int RetextureBuild(struct Recipe *recipe)
 		fprintf(stderr, "error writing to file '%s'\n", recipe->yarName);
 		exit(EXIT_FAILURE);
 	}
+	fclose(out);
 	
 	free(data);
 	free(buffer);


### PR DESCRIPTION
With this update, z64yartool be used for managing uncompressed headerless texture banks. Confirmed these changes don't break the existing features (the output files have the same checksums as files generated by v1.0.1).

Intended to be used with this z64rom feature: https://github.com/z64utils/z64rom/pull/3 and this z64scene feature: https://github.com/z64me/z64scene/commit/f856d07f0026e03bac5d42375f775acc0e218ee3